### PR TITLE
Reorganize detrending (#112)

### DIFF
--- a/xrft/tests/test_xrft.py
+++ b/xrft/tests/test_xrft.py
@@ -12,7 +12,7 @@ import numpy.testing as npt
 import xarray.testing as xrt
 
 import xrft
-
+from xrft.xrft import _apply_detrend
 
 @pytest.fixture()
 def sample_data_3d():
@@ -73,53 +73,175 @@ def numpy_detrend(da):
     m_est = np.dot(np.dot(spl.inv(np.dot(G.T, G)), G.T), d_obs)
     d_est = np.dot(G, m_est)
 
-    lin_trend = np.reshape(d_est, N)
+    linear_fit = np.reshape(d_est, N)
 
-    return da - lin_trend
+    return da - linear_fit
 
 def test_detrend():
     N = 16
-    x = np.arange(N+1)
-    y = np.arange(N-1)
-    t = np.linspace(-int(N/2), int(N/2), N-6)
-    z = np.arange(int(N/2))
-    d4d = (t[:,np.newaxis,np.newaxis,np.newaxis]
-            + z[np.newaxis,:,np.newaxis,np.newaxis]
-            + y[np.newaxis,np.newaxis,:,np.newaxis]
-            + x[np.newaxis,np.newaxis,np.newaxis,:]
+
+    nt, nz, ny, nx = N-6, int(N/2), N-1, N+1
+
+    t = np.linspace(-int(N/2), int(N/2), nt)
+    z = np.arange(nz)
+    y = np.arange(ny)
+    x = np.arange(nx)
+
+    # create some noise; make sure it has no trend
+    def detrended_noise(N, amplitude=1.0):
+        return sps.detrend(amplitude*np.random.rand(N))
+
+    noise_t = detrended_noise(nt, amplitude=0.12)
+    noise_z = detrended_noise(nz, amplitude=0.3)
+    noise_y = detrended_noise(ny, amplitude=0.2)
+    noise_x = detrended_noise(nx, amplitude=0.1)
+
+    # trended data
+    data_t =  1.0*t + noise_t
+    data_z =  0.2*z + noise_z
+    data_y = -0.3*y + noise_y
+    data_x =  0.5*x + noise_x
+
+    # construct some 2D, 3D, 4D numpy arrays to be used as tests for the detrendn function
+    array2D = (data_y[:,np.newaxis] + data_x[np.newaxis,:])
+
+    array2D_detrended = (noise_y[:,np.newaxis] + noise_x[np.newaxis,:])
+    array2D_detrended = array2D_detrended - array2D_detrended.mean()[np.newaxis,np.newaxis]
+
+    array3D = (data_t[:,np.newaxis,np.newaxis]
+            + data_y[np.newaxis,:,np.newaxis]
+            + data_x[np.newaxis,np.newaxis,:]
           )
-    da4d = xr.DataArray(d4d, dims=['time','z','y','x'],
-                     coords={'time':range(len(t)),'z':range(len(z)),'y':range(len(y)),
-                             'x':range(len(x))}
+
+    array3D_detrended = (noise_t[:,np.newaxis,np.newaxis]
+            + noise_y[np.newaxis,:,np.newaxis]
+            + noise_x[np.newaxis,np.newaxis,:]
+          )
+    array3D_detrended = array3D_detrended - array3D_detrended.mean()[np.newaxis,np.newaxis,np.newaxis]
+    
+    array4D = (data_t[:,np.newaxis,np.newaxis,np.newaxis]
+            + data_z[np.newaxis,:,np.newaxis,np.newaxis]
+            + data_y[np.newaxis,np.newaxis,:,np.newaxis]
+            + data_x[np.newaxis,np.newaxis,np.newaxis,:]
+          )
+
+    array4D_detrendedy = (data_t[:,np.newaxis,np.newaxis,np.newaxis]
+            + data_z[np.newaxis,:,np.newaxis,np.newaxis]
+            + noise_y[np.newaxis,np.newaxis,:,np.newaxis]
+            + data_x[np.newaxis,np.newaxis,np.newaxis,:]
+          )
+    array4D_detrendedy = array4D_detrendedy - array4D_detrendedy.mean(axis=2)[:, :, np.newaxis, :]
+
+    array4D_detrendedxy = (data_t[:,np.newaxis,np.newaxis,np.newaxis]
+            + data_z[np.newaxis,:,np.newaxis,np.newaxis]
+            + noise_y[np.newaxis,np.newaxis,:,np.newaxis]
+            + noise_x[np.newaxis,np.newaxis,np.newaxis,:]
+          )
+    array4D_detrendedxy = array4D_detrendedxy - array4D_detrendedxy.mean(axis=(2,3))[:,:,np.newaxis,np.newaxis]
+
+    array4D_detrendedxyz = (data_t[:,np.newaxis,np.newaxis,np.newaxis]
+            + noise_z[np.newaxis,:,np.newaxis,np.newaxis]
+            + noise_y[np.newaxis,np.newaxis,:,np.newaxis]
+            + noise_x[np.newaxis,np.newaxis,np.newaxis,:]
+          )
+    array4D_detrendedxyz = array4D_detrendedxyz - array4D_detrendedxyz.mean(axis=(1,2,3))[:,np.newaxis,np.newaxis,np.newaxis]
+
+    array4D_nomean = array4D - array4D.mean()[np.newaxis, np.newaxis, np.newaxis, np.newaxis]
+    
+    # now construct the equivalent 2D, 3D, 4D data arrays
+    da2D = xr.DataArray(array2D, dims=['y','x'], coords={'y':y,'x':x})
+    
+    da2D_detrended = xr.DataArray(array2D_detrended, dims=['y','x'], coords={'y':y,'x':x})
+    
+    da3D = xr.DataArray(array3D, dims=['time','y','x'],
+                     coords={'time':t,'y':y,'x':x}
+                     )
+    da4D = xr.DataArray(array4D, dims=['time','z','y','x'],
+                     coords={'time':t,'z':z,'y':y,'x':x}
+                     )
+
+    da3D_detrended = xr.DataArray(array3D_detrended,dims=['time','y','x'],
+                     coords={'time':t,'y':y,'x':x}
+                     )
+
+    da4D_detrendedy = xr.DataArray(array4D_detrendedy, dims=['time','z','y','x'],
+                     coords={'time':t,'z':z,'y':y,'x':x}
+                     )
+
+    da4D_detrendedxy = xr.DataArray(array4D_detrendedxy, dims=['time','z','y','x'],
+                     coords={'time':t,'z':z,'y':y,'x':x}
+                     )
+
+    da4D_detrendedxyz = xr.DataArray(array4D_detrendedxyz, dims=['time','z','y','x'],
+                     coords={'time':t,'z':z,'y':y,'x':x}
                      )
 
     func = xrft.detrend_wrap(xrft.detrendn)
 
+    # let's begin testing
+
+    # detrend all dims of 2D dataarray
+    da = da2D
+    da_prime = _apply_detrend(da, {'x', 'y'}, [0, 1], 'linear')
+    npt.assert_allclose(da_prime, da2D_detrended)
+    
+    # detrend all dims of 3D dataarray
+    da = da3D
+    da_prime = _apply_detrend(da, {'time', 'x', 'y'}, [0, 1, 2], 'linear')
+    npt.assert_allclose(da_prime, da3D_detrended)
+    
     #########
     # Chunk along the `time` axis
     #########
-    da = da4d.chunk({'time': 1})
-    with pytest.raises(ValueError):
-        func(da.data, axes=[0]).compute
-    with pytest.raises(ValueError):
-        func(da.data, axes=[0,1,2,3]).compute()
-    da_prime = func(da.data, axes=[2]).compute()
-    npt.assert_allclose(da_prime[0,0], sps.detrend(d4d[0,0], axis=0))
+    da = da4D.chunk({'time': 1})
+    
+    # test detrending along 1 dimension
+    da_prime = _apply_detrend(da, 'y', 2, 'linear')
+    npt.assert_allclose(da_prime, da4D_detrendedy)
+    npt.assert_allclose(da_prime[0,0,:,0].data, noise_y)
+
+    # test detrending along >1 dimensions
     da_prime = func(da.data, axes=[1,2,3]).compute()
-    npt.assert_allclose(da_prime[0],
-                        xrft.detrendn(d4d[0], axes=[0,1,2]))
+    npt.assert_allclose(da_prime.data, array4D_detrendedxyz)
+    npt.assert_allclose(da_prime, da4D_detrendedxyz)
+
+    # detrend along all 4 dimensions should only work for 'constant'
+    with pytest.raises(NotImplementedError):
+        func(da.data, axes=[0,1,2,3]).compute()
+    
+    with pytest.raises(NotImplementedError):
+        _apply_detrend(da, {'time', 'z', 'y', 'x'}, [0, 1, 2, 3],  'linear').compute()
+    
+    npt.assert_allclose(_apply_detrend(da, {'time', 'z', 'y', 'x'}, [0, 1, 2, 3],  'constant').compute(), array4D_nomean)
+
+    da = da3D.chunk({'time': None})
+    # test detrending along all dimensions (total dimensions <4)
+    da_prime = func(da.data,axes=[0,1,2]).compute()
+    npt.assert_allclose(da_prime, da3D_detrended)
 
     #########
     # Chunk along the `time` and `z` axes
     #########
-    da = da4d.chunk({'time':1, 'z':1})
+    da = da4D.chunk({'time':1, 'z':1})
     with pytest.raises(ValueError):
         func(da.data, axes=[1,2]).compute()
     with pytest.raises(ValueError):
         func(da.data, axes=[2,2]).compute()
     da_prime = func(da.data, axes=[2,3]).compute()
-    npt.assert_allclose(da_prime[0,0],
-                        xrft.detrendn(d4d[0,0], axes=[0,1]))
+    npt.assert_allclose(da_prime, da4D_detrendedxy)
+
+    # for linear detrending of 2 or 3 dimensions
+    
+    # if dataarray is not chunked raise error
+    da = da4D
+    with pytest.raises(ValueError):
+        _apply_detrend(da, {'z', 'x'}, [1, 2],  'linear').compute()
+        
+    # if the dimensions not being detrended don't have chunk length = 1 then error should be raised
+    da = da4D.chunk({'time':2, 'z':2})
+    with pytest.raises(ValueError):
+        _apply_detrend(da, {'z', 'x'}, [1, 2],  'linear').compute()
+
 
 class TestDFTImag(object):
     def test_dft_1d(self, test_data_1d):
@@ -254,8 +376,6 @@ class TestDFTImag(object):
                          coords={'time':range(N),'z':range(N),
                                 'y':range(N),'x':range(N)}
                          )
-        with pytest.raises(ValueError):
-            xrft.dft(da.chunk({'time':8}), dim=['y','x'], detrend='linear')
         ft = xrft.dft(da, shift=False)
         npt.assert_almost_equal(ft.values, np.fft.fftn(da.values))
 
@@ -421,12 +541,18 @@ class TestSpectrum(object):
         npt.assert_almost_equal(np.ma.masked_invalid(ps).mask.sum(), 0.)
 
         ### Remove least-square fit
-        ps = xrft.power_spectrum(da, dim=['y','x'],
+        if not dask:
+            with pytest.raises(ValueError):
+                ps = xrft.power_spectrum(da, dim=['y','x'],
+                                        window=True, density=False, detrend='linear'
+                                        )
+        else:
+            ps = xrft.power_spectrum(da, dim=['y','x'],
                                 window=True, density=False, detrend='linear'
                                 )
-        daft = xrft.dft(da, dim=['y','x'], window=True, detrend='linear')
-        npt.assert_almost_equal(ps.values, np.real(daft*np.conj(daft)))
-        npt.assert_almost_equal(np.ma.masked_invalid(ps).mask.sum(), 0.)
+            daft = xrft.dft(da, dim=['y','x'], window=True, detrend='linear')
+            npt.assert_almost_equal(ps.values, np.real(daft*np.conj(daft)))
+            npt.assert_almost_equal(np.ma.masked_invalid(ps).mask.sum(), 0.)
 
     @pytest.mark.parametrize("dask", [False, True])
     def test_cross_spectrum(self, dask):
@@ -557,7 +683,7 @@ def test_parseval(chunks_to_segments):
                     dims=['x','y'], coords={'x':range(N), 'y':range(N)})
     da2 = xr.DataArray(np.random.rand(N,N),
                     dims=['x','y'], coords={'x':range(N), 'y':range(N)})
-    
+
     if chunks_to_segments:
         n_segments = 2
         # Chunk da and da2 into n_segments
@@ -575,24 +701,24 @@ def test_parseval(chunks_to_segments):
         delta = diff[0]
         delta_x.append(delta)
     delta_xy = np.asarray(delta_x).prod() # Area of the spacings
-    
+
     ### Test Parseval's theorem for power_spectrum with `window=False` and detrend=None
-    ps = xrft.power_spectrum(da, 
+    ps = xrft.power_spectrum(da,
                              chunks_to_segments=chunks_to_segments)
     # If n_segments > 1, use xrft._stack_chunks() to stack each segment along a new dimension
     da_seg = xrft.xrft._stack_chunks(da, dim).squeeze() if chunks_to_segments else da
     da_prime = da_seg
     # Check that the (rectangular) integral of the spectrum matches the energy
-    npt.assert_almost_equal((1 / delta_xy) * ps.mean(fftdim).values, 
-                            (da_prime**2).mean(dim).values, 
+    npt.assert_almost_equal((1 / delta_xy) * ps.mean(fftdim).values,
+                            (da_prime**2).mean(dim).values,
                             decimal=5)
-    
+
     ### Test Parseval's theorem for power_spectrum with `window=True` and detrend='constant'
-    # Note that applying a window weighting reduces the energy in a signal and we have to account 
-    # for this reduction when testing Parseval's theorem. 
-    ps = xrft.power_spectrum(da, 
-                             window=True, 
-                             detrend='constant', 
+    # Note that applying a window weighting reduces the energy in a signal and we have to account
+    # for this reduction when testing Parseval's theorem.
+    ps = xrft.power_spectrum(da,
+                             window=True,
+                             detrend='constant',
                              chunks_to_segments=chunks_to_segments)
     # If n_segments > 1, use xrft._stack_chunks() to stack each segment along a new dimension
     da_seg = xrft.xrft._stack_chunks(da, dim).squeeze() if chunks_to_segments else da
@@ -606,21 +732,21 @@ def test_parseval(chunks_to_segments):
         dims=dim, coords=da.coords
     )
     # Check that the (rectangular) integral of the spectrum matches the windowed variance
-    npt.assert_almost_equal((1 / delta_xy) * ps.mean(fftdim).values, 
-                            ((da_prime*window)**2).mean(dim).values, 
+    npt.assert_almost_equal((1 / delta_xy) * ps.mean(fftdim).values,
+                            ((da_prime*window)**2).mean(dim).values,
                             decimal=5)
-    
+
     ### Test Parseval's theorem for cross_spectrum with `window=True` and detrend='constant'
-    cs = xrft.cross_spectrum(da, da2, 
-                             window=True, 
+    cs = xrft.cross_spectrum(da, da2,
+                             window=True,
                              detrend='constant',
                              chunks_to_segments=chunks_to_segments)
     # If n_segments > 1, use xrft._stack_chunks() to stack each segment along a new dimension
     da2_seg = xrft.xrft._stack_chunks(da2, dim).squeeze() if chunks_to_segments else da2
     da2_prime = da2_seg - da2_seg.mean(dim=dim)
     # Check that the (rectangular) integral of the cross-spectrum matches the windowed co-variance
-    npt.assert_almost_equal((1 / delta_xy) * cs.mean(fftdim).values, 
-                            ((da_prime*window) * (da2_prime*window)).mean(dim).values, 
+    npt.assert_almost_equal((1 / delta_xy) * cs.mean(fftdim).values,
+                            ((da_prime*window) * (da2_prime*window)).mean(dim).values,
                             decimal=5)
 
     ### Test Parseval's theorem for a 3D case with `window=True` and `detrend='linear'`
@@ -629,9 +755,9 @@ def test_parseval(chunks_to_segments):
                            dims=['time','y','x'],
                            coords={'time':range(N), 'y':range(N), 'x':range(N)}
                           ).chunk({'time':1})
-        ps = xrft.power_spectrum(d3d, 
-                                 dim=['x','y'], 
-                                 window=True, 
+        ps = xrft.power_spectrum(d3d,
+                                 dim=['x','y'],
+                                 window=True,
                                  detrend='linear')
         npt.assert_almost_equal((1 / delta_xy) * ps[0].values.mean(),
                                 ((numpy_detrend(d3d[0].values)*window)**2).mean(),


### PR DESCRIPTION
* implement polyfit for 1d detrend

* fixed polyfit arguments

* bypass multidimensional fft tests if 1d fft

* modifies test_detrend() to work with polyfit implementation

* Got rid of unnecessary if statement

* first need to deal with axes=None

* test a case that detrends with axes=None

* enhances test_detrend
now the test actually makes sure that the output of the detredn function for 1D detrending is what expected

* avoid tautology in test_detrend()

* better organizes test_detrend + some comments

* better organizes test_detrend + some comments

* Revert "better organizes test_detrend + some comments"

This reverts commit 5335123e16faad1b6e1e21c4fd256df03b4941a2.

* better organize test_detrend()

* reorganizing detrend functions

* Clean detrending routines

* Remove warning for dims not being detrended with chunks not equal to 1

* NotImplementedError instead of ValueError

* removes redundant checks

* make _apply_detrend private again

* Raise error if non-detrending axes don't have chunks of length 1

* adds another case to test the 'please rechunk to length=1' error message

* homogenizes notation: both lin_trend --> linear_fit & fit --> linear_fit

* make sure that all cases not implemented are covered in tests

* removes debugging printout

* adds few more cases in test_detrend() to cover all warnings raised

* enhance tests even more

Co-authored-by: Paige Martin <paige@Paiges-MacBook-Pro.local>
Co-authored-by: Navid Constantinou <navidcy@gmail.com>